### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/orders.js
+++ b/node-rest-api/api/routes/orders.js
@@ -7,6 +7,15 @@
 const express = require('express');
 const router = express.Router();
 
+const RateLimit = require('express-rate-limit');
+
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+router.use(limiter);
+
 const checkAuth = require('../middleware/check-auth');
 
 const OrdersController =require('../controllers/orders.controller');

--- a/node-rest-api/package.json
+++ b/node-rest-api/package.json
@@ -29,7 +29,8 @@
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^8.9.5",
     "morgan": "^1.10.1",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/1](https://github.com/jorgeemherrera/DataClient/security/code-scanning/1)

In general, the problem is fixed by introducing a rate‑limiting middleware (for example, using the widely used `express-rate-limit` package) and applying it to the routes that perform expensive operations, such as the order endpoints that likely interact with a database. The middleware should be invoked before the controllers (and typically alongside authentication) so that abusive clients are blocked early without fully executing the business logic.

For this specific file (`node-rest-api/api/routes/orders.js`), the best fix without changing existing behavior is:
- Import and configure a rate limiter specifically for this router using `express-rate-limit`.
- Apply the limiter to all routes in this router via `router.use(limiter)`, so that all order operations (list, create, get by id, delete) share the same rate limit.
- Keep the existing `checkAuth` middleware and controller bindings unchanged; only add the new middleware in the chain.

Concretely:
- At the top of `orders.js`, after the existing `require('express')` and router setup, add `require('express-rate-limit')` and define a `limiter` with reasonable defaults (e.g., 100 requests per 15 minutes per IP).
- Immediately after creating the router, call `router.use(limiter);` so it applies to all subsequent routes.
No other files or lines need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
