### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/users.js
+++ b/node-rest-api/api/routes/users.js
@@ -14,11 +14,16 @@ const signupLimiter = RateLimit({
   max: 20, // limit each IP to 20 signup requests per `window` (here, per 15 minutes)
 });
 
+const getUsersLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 get-all-users requests per window
+});
+
 const UsersController =require('../controllers/users.controller');
 
 router.post('/signup', signupLimiter, UsersController.users_signup_user);
 
-router.get('/', UsersController.users_get_all);
+router.get('/', getUsersLimiter, UsersController.users_get_all);
 
 router.post('/login', UsersController.users_login_user);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/10](https://github.com/jorgeemherrera/DataClient/security/code-scanning/10)

In general, the fix is to ensure that any route which performs expensive operations (like database queries) is protected by suitable rate limiting middleware. This is commonly done with `express-rate-limit`, which you are already using for `/signup`. Each rate limiter can have its own window and maximum request settings, depending on how sensitive or heavy the endpoint is.

The best, least intrusive fix here is to define a new rate limiter specifically for the `users_get_all` route (for example, `getUsersLimiter`) using the already imported `express-rate-limit`, and then insert that limiter into the middleware chain for `router.get('/')`. This keeps existing functionality and route signatures unchanged while adding protection against abusive request rates. Concretely, in `node-rest-api/api/routes/users.js`, right after `signupLimiter` is defined (around lines 12–15), we add another limiter configuration for the "get all users" operation. Then, at line 21, we modify `router.get('/', UsersController.users_get_all);` so that it becomes `router.get('/', getUsersLimiter, UsersController.users_get_all);`. No new imports are required because `RateLimit` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
