### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/users.js
+++ b/node-rest-api/api/routes/users.js
@@ -19,13 +19,18 @@ const getUsersLimiter = RateLimit({
   max: 100, // limit each IP to 100 get-all-users requests per window
 });
 
+const loginLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 login requests per window
+});
+
 const UsersController =require('../controllers/users.controller');
 
 router.post('/signup', signupLimiter, UsersController.users_signup_user);
 
 router.get('/', getUsersLimiter, UsersController.users_get_all);
 
-router.post('/login', UsersController.users_login_user);
+router.post('/login', loginLimiter, UsersController.users_login_user);
 
 router.delete('/:userId', checkAuth, UsersController.users_delete_user)
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/11](https://github.com/jorgeemherrera/DataClient/security/code-scanning/11)

In general, the fix is to protect the login route with rate limiting, using the already imported `express-rate-limit`. This ensures that high-frequency requests to the login endpoint cannot trigger unbounded database work and mitigates brute-force and denial-of-service attempts against authentication.

Concretely, in `node-rest-api/api/routes/users.js`, we should define a new rate limiter configuration for the login route, similar to `signupLimiter` and `getUsersLimiter`, and then apply it as middleware on `router.post('/login', ...)`. The limiter should be declared once near the other limiter definitions (around lines 12–20) and then referenced on the login route definition at line 28. No new imports are needed because `RateLimit` is already required on line 10, and we will not change any existing behavior of the controller; we only add middleware that restricts abusive request rates.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
