### PR TITLE
Potential fix for code scanning alert no. 12: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/users.js
+++ b/node-rest-api/api/routes/users.js
@@ -24,6 +24,11 @@ const loginLimiter = RateLimit({
   max: 100, // limit each IP to 100 login requests per window
 });
 
+const deleteUserLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 delete-user requests per window
+});
+
 const UsersController =require('../controllers/users.controller');
 
 router.post('/signup', signupLimiter, UsersController.users_signup_user);
@@ -32,6 +37,6 @@ router.get('/', getUsersLimiter, UsersController.users_get_all);
 
 router.post('/login', loginLimiter, UsersController.users_login_user);
 
-router.delete('/:userId', checkAuth, UsersController.users_delete_user)
+router.delete('/:userId', checkAuth, deleteUserLimiter, UsersController.users_delete_user)
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/12](https://github.com/jorgeemherrera/DataClient/security/code-scanning/12)

In general, the fix is to apply an appropriate `express-rate-limit` middleware to the `DELETE /:userId` route, similar to how `signupLimiter`, `getUsersLimiter`, and `loginLimiter` are used. This ensures that even authenticated clients cannot flood the endpoint with a large number of expensive deletion requests in a short period of time.

The best way to fix this without changing existing functionality is to define a new rate limiter dedicated to delete-user operations (or reuse an existing one if policy-wise appropriate) and add it into the middleware chain for the `router.delete('/:userId', ...)` route. To keep the behavior consistent with the rest of the file, we can create a `deleteUserLimiter` using the already imported `RateLimit` from `express-rate-limit`, with a sensible cap (e.g., a very low number like 10 delete attempts per 15 minutes per IP, since deletes are rare and sensitive). Then we update the delete route to use both `checkAuth` and the new limiter. All required imports are already in place (`RateLimit` is imported at line 10), so the only code changes are: (1) add a new constant `deleteUserLimiter` near the other limiter definitions (around lines 22–25), and (2) update the delete route at line 35 to include this middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
