### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -12,6 +12,8 @@ const checkAuth = require('../middleware/check-auth');
 
 const ProductsController =require('../controllers/products.controller');
 
+const RateLimit = require('express-rate-limit');
+
 const storage = multer.diskStorage({
     destination: function(req, file, cb){
         cb(null, './uploads/');
@@ -40,10 +42,15 @@ const upload = multer({
 
 const Product = require('../models/product');
 
+const productsGetAllLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs for this endpoint
+});
+
 /**
  * the rest of the route is on app.js
  */
-router.get('/', ProductsController.products_get_all);
+router.get('/', productsGetAllLimiter, ProductsController.products_get_all);
 
 router.post('/', checkAuth, upload.single('productImage'), ProductsController.products_create_product);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/14](https://github.com/jorgeemherrera/DataClient/security/code-scanning/14)

In general, the right fix is to introduce an HTTP rate-limiting middleware (such as `express-rate-limit`) and apply it to routes that perform expensive operations, especially unauthenticated or broadly accessible ones. This middleware should be configured with reasonable limits (e.g., a maximum number of requests per IP in a time window) and then inserted in the middleware chain before the controller function.

For this specific file, we can fix the issue by: (1) requiring `express-rate-limit` at the top of `node-rest-api/api/routes/products.js`, (2) defining a limiter instance with appropriate `windowMs` and `max` values, and (3) inserting that limiter into the `router.get('/', ...)` route so that `ProductsController.products_get_all` is rate-limited without changing its internal behavior. We will only touch this file, keep existing imports unchanged, and add one new import and a limiter constant. The controller logic and other routes remain the same, so existing functionality is preserved, with the addition of rate limiting on the product-listing endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
