### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -47,6 +47,11 @@ const productsGetAllLimiter = RateLimit({
     max: 100 // limit each IP to 100 requests per windowMs for this endpoint
 });
 
+const productsUpdateLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 update requests per windowMs for this endpoint
+});
+
 /**
  * the rest of the route is on app.js
  */
@@ -56,7 +61,7 @@ router.post('/', checkAuth, upload.single('productImage'), ProductsController.pr
 
 router.get('/:productId', ProductsController.products_get_product);
 
-router.patch('/:productId', checkAuth, ProductsController.products_update_product);
+router.patch('/:productId', checkAuth, productsUpdateLimiter, ProductsController.products_update_product);
 
 router.delete('/:productId', checkAuth, ProductsController.products_delete_product);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/17](https://github.com/jorgeemherrera/DataClient/security/code-scanning/17)

In general, the fix is to apply rate limiting middleware to the `PATCH /:productId` route, similar to how `productsGetAllLimiter` is applied to `GET /`. Since `express-rate-limit` is already imported as `RateLimit` and used to define `productsGetAllLimiter`, we can create another limiter instance tailored for update operations and attach it to the patch route.

Concretely, in `node-rest-api/api/routes/products.js`, define a new limiter (e.g., `productsUpdateLimiter`) near the existing `productsGetAllLimiter` configuration, using `RateLimit({...})`. Then update the `router.patch('/:productId', ...)` definition to include this limiter between `checkAuth` and the controller handler. This preserves existing authentication and controller behavior, while enforcing a maximum number of update requests per IP in a time window. No other files or imports need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
