### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -52,6 +52,11 @@ const productsUpdateLimiter = RateLimit({
     max: 100 // limit each IP to 100 update requests per windowMs for this endpoint
 });
 
+const productsDeleteLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 delete requests per windowMs for this endpoint
+});
+
 /**
  * the rest of the route is on app.js
  */
@@ -63,6 +68,6 @@ router.get('/:productId', ProductsController.products_get_product);
 
 router.patch('/:productId', checkAuth, productsUpdateLimiter, ProductsController.products_update_product);
 
-router.delete('/:productId', checkAuth, ProductsController.products_delete_product);
+router.delete('/:productId', checkAuth, productsDeleteLimiter, ProductsController.products_delete_product);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/19](https://github.com/jorgeemherrera/DataClient/security/code-scanning/19)

In general, to fix missing rate limiting on an Express route that performs expensive or sensitive operations, you add an `express-rate-limit` middleware and attach it to the route, just as with any other middleware. This ensures that, per IP (or other key), only a bounded number of requests are processed within a time window, mitigating denial‑of‑service risks.

For this specific file `node-rest-api/api/routes/products.js`, the best fix is to define a new rate limiter instance for delete operations—similar to `productsGetAllLimiter` and `productsUpdateLimiter`—and then insert it into the `router.delete('/:productId', ...)` chain. This approach keeps existing behavior intact while aligning with the pattern already used in the file. Concretely:
- Above the route definitions, add something like `const productsDeleteLimiter = RateLimit({ windowMs: 15 * 60 * 1000, max: 100 });`.
- Modify line 66 so that the delete route uses `productsDeleteLimiter` between `checkAuth` and `ProductsController.products_delete_product`.
No new imports are needed because `RateLimit` from `express-rate-limit` is already required at line 15.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
