### PR TITLE
Potential fix for code scanning alert no. 23: Database query built from user-controlled sources

### DIFF
--- a/node-rest-api/api/controllers/users.controller.js
+++ b/node-rest-api/api/controllers/users.controller.js
@@ -107,7 +107,13 @@ exports.users_get_all = (req, res, next) => {
 }
 
 exports.users_login_user = (req,res,next) =>{
-    User.find({ email: req.body.email})
+    const email = req.body && typeof req.body.email === 'string' ? req.body.email : null;
+    if (!email) {
+        return res.status(400).json({
+            message: 'Invalid email'
+        });
+    }
+    User.find({ email: { $eq: email } })
     .exec()
     .then(user => {
         if(user.length < 1) {


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/23](https://github.com/jorgeemherrera/DataClient/security/code-scanning/23)

In general, to fix this class of problem in MongoDB/Mongoose code, you must ensure that any user input used in query objects is validated and treated as a literal value, not an arbitrary object. That can be done either by enforcing the expected primitive type (e.g., ensuring `typeof email === "string"`), or by explicitly wrapping the value with an operator like `$eq` (`{ email: { $eq: email } }`) to prevent an attacker from injecting query operators.

For this specific `users_login_user` controller, the safest and least intrusive fix is to:
1. Extract `req.body.email` into a local variable.
2. Validate that it is a string (and optionally non-empty / trimmed).
3. If validation fails, immediately reject the request with a 400 or 401 response.
4. Use the validated string in the Mongoose query, not `req.body` directly. Optionally wrap it with `$eq` to make the intent explicit.

This change is confined to `users_login_user` around line 110 in `node-rest-api/api/controllers/users.controller.js`. No new external libraries are needed; plain JavaScript type checks are sufficient. Functionality is preserved (email-based login) while preventing complex objects from being interpreted as query operators.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
