### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/node-rest-api/api/controllers/users.controller.js
+++ b/node-rest-api/api/controllers/users.controller.js
@@ -12,6 +12,11 @@ const User = require('../models/user');
 
 exports.users_signup_user = (req, res, next) => {
     // valid email
+    if (typeof req.body.email !== 'string') {
+        return res.status(400).json({
+            message: 'Invalid email'
+        });
+    }
     User.find({email: req.body.email})
     .exec()
     .then(user =>{


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/22](https://github.com/jorgeemherrera/DataClient/security/code-scanning/22)

In general, the fix is to ensure user-controlled data is interpreted strictly as a literal value in the query, not as a query object. For MongoDB via Mongoose, this can be achieved by (a) validating that the user input is of an expected primitive type (e.g., a string) before using it in the query, or (b) using the `$eq` operator to force a literal comparison, or both. Either approach prevents an attacker from supplying an object like `{ $ne: null }` that would otherwise alter query behavior.

For this function, the minimal, non‑functional‑changing fix is to validate that `req.body.email` is a string before calling `User.find`. If it is not a string, we return a 400 Bad Request and stop processing. Once we guarantee it is a string, using `{ email: req.body.email }` is safe from NoSQL injection in this context. This means editing `users_signup_user` in `node-rest-api/api/controllers/users.controller.js` to add a type check immediately after entering the function and before `User.find({email: req.body.email})`. No additional imports are required; we can use plain JavaScript `typeof` for validation.

Concretely:
- In `exports.users_signup_user`, insert a guard:

```js
if (typeof req.body.email !== 'string') {
    return res.status(400).json({ message: 'Invalid email' });
}
```

- Place this check just before the `User.find({email: req.body.email})` call.
- This preserves existing behavior for valid requests while safely rejecting potentially malicious ones.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
