### PR TITLE
Potential fix for code scanning alert no. 21: Database query built from user-controlled sources

### DIFF
--- a/node-rest-api/api/controllers/orders.controller.js
+++ b/node-rest-api/api/controllers/orders.controller.js
@@ -38,7 +38,13 @@ exports.orders_get_all = (req, res, next) => {
 }
 
 exports.orders_create_order = (req, res, next) => {
-    Product.findById(req.body.productId)
+    const productId = req.body.productId;
+    if (typeof productId !== 'string' || !mongoose.Types.ObjectId.isValid(productId)) {
+        return res.status(400).json({
+            message: 'Invalid productId'
+        });
+    }
+    Product.findById(productId)
         .then(product => {
             if(!product) {
                 return res.status(404).json({
@@ -48,7 +54,7 @@ exports.orders_create_order = (req, res, next) => {
             const order = new Order ({
                 _id: mongoose.Types.ObjectId(),
                 quantity: req.body.quantity,
-                product: req.body.productId
+                product: productId
             });
             return order.save() 
         })


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/21](https://github.com/jorgeemherrera/DataClient/security/code-scanning/21)

In general, to fix this class of issue in MongoDB/Mongoose code, you should ensure that untrusted values used in queries are treated strictly as literals and not as query objects. That usually means validating types (e.g., ensuring a string), validating format (e.g., checking it is a valid ObjectId), or wrapping them with operators like `$eq` (`{ _id: { $eq: value } }`). Avoid ever allowing user‑supplied objects to be used directly as query filters.

For this specific case in `orders_create_order` (file `node-rest-api/api/controllers/orders.controller.js`, around line 40), we should validate `req.body.productId` before using it in `Product.findById` or as the `product` field of a new `Order`. The best low‑impact fix is:
- Extract `productId` into a local variable.
- Check that it is a string and that it passes `mongoose.Types.ObjectId.isValid(productId)`.
- If it fails, return a 400 response (bad request) instead of querying the database.
- Use the validated `productId` variable in `findById` and when constructing the `Order`.

This preserves existing functionality (creating orders for valid products) while ensuring that only well‑formed ObjectId strings are used in the query and stored. No additional imports are required; we already import `mongoose` and can use `mongoose.Types.ObjectId.isValid`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
