### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/users.js
+++ b/node-rest-api/api/routes/users.js
@@ -37,6 +37,6 @@ router.get('/', getUsersLimiter, UsersController.users_get_all);
 
 router.post('/login', loginLimiter, UsersController.users_login_user);
 
-router.delete('/:userId', checkAuth, deleteUserLimiter, UsersController.users_delete_user)
+router.delete('/:userId', deleteUserLimiter, checkAuth, UsersController.users_delete_user)
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/24](https://github.com/jorgeemherrera/DataClient/security/code-scanning/24)

In general, to fix this problem you must ensure that any potentially expensive middleware (like authentication/authorization) is protected by a rate limiter that runs before it. For Express route definitions, this usually means ordering the middleware so that the rate‑limiting middleware appears earlier in the list than any costly middlewares.

For this specific file, the `/users/:userId` DELETE route currently applies `checkAuth` before `deleteUserLimiter`. The fix is to reorder the middleware so that `deleteUserLimiter` executes before `checkAuth`. This keeps the same set of middlewares and the same controller function but ensures that abusive traffic is throttled before authorization logic is triggered. Only line 40 in `node-rest-api/api/routes/users.js` needs to be updated; no new imports or additional functions are required, since `express-rate-limit` is already in use and configured for other routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
