### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -47,6 +47,11 @@ const productsGetAllLimiter = RateLimit({
     max: 100 // limit each IP to 100 requests per windowMs for this endpoint
 });
 
+const productsGetByIdLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 get-by-id requests per windowMs for this endpoint
+});
+
 const productsUpdateLimiter = RateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100 // limit each IP to 100 update requests per windowMs for this endpoint
@@ -69,7 +74,7 @@ router.get('/', productsGetAllLimiter, ProductsController.products_get_all);
 
 router.post('/', checkAuth, productsCreateLimiter, upload.single('productImage'), ProductsController.products_create_product);
 
-router.get('/:productId', ProductsController.products_get_product);
+router.get('/:productId', productsGetByIdLimiter, ProductsController.products_get_product);
 
 router.patch('/:productId', productsUpdateLimiter, checkAuth, ProductsController.products_update_product);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/26](https://github.com/jorgeemherrera/DataClient/security/code-scanning/26)

In general, to fix missing rate limiting, attach an appropriate `express-rate-limit` middleware to any route that triggers relatively expensive operations (like database access) and is directly exposed over HTTP. This can be done with a global limiter (`app.use(limiter)`) or with per-route limiters created via `RateLimit({ ... })`. In this file, the project already uses per-route limiters for the other product endpoints, so the best, least-disruptive fix is to define a new limiter for the `GET /:productId` route and apply it there, leaving existing behavior unchanged.

Concretely, in `node-rest-api/api/routes/products.js`, add a new limiter configuration constant (e.g., `productsGetByIdLimiter`) right alongside the existing `productsGetAllLimiter`, `productsUpdateLimiter`, `productsDeleteLimiter`, and `productsCreateLimiter`. It should use the same `windowMs` and `max` settings to remain consistent. Then update line 72 to insert this new limiter as middleware for `router.get('/:productId', ...)`, keeping the original handler order intact. No new imports are required because `RateLimit` is already imported on line 15, and you don’t need to modify any other routes or controllers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
