### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -78,6 +78,6 @@ router.get('/:productId', productsGetByIdLimiter, ProductsController.products_ge
 
 router.patch('/:productId', productsUpdateLimiter, checkAuth, ProductsController.products_update_product);
 
-router.delete('/:productId', checkAuth, productsDeleteLimiter, ProductsController.products_delete_product);
+router.delete('/:productId', productsDeleteLimiter, checkAuth, ProductsController.products_delete_product);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/26](https://github.com/jorgeemherrera/DataClient/security/code-scanning/26)

In general, the route that performs authorization and expensive operations should have a rate limiter applied *before* the authorization middleware so that abusive traffic is throttled before it reaches the auth and business logic. We should not alter existing behavior beyond middleware ordering, nor add global app-level changes since we must stay within the shown snippet.

The best minimal fix is to keep using the existing `productsDeleteLimiter` but move it so that it is executed before `checkAuth` on the `DELETE /:productId` route. This preserves all existing controllers, middlewares, and limit settings while ensuring that authorization does not run on requests that are already over the rate limit. Concretely, in `node-rest-api/api/routes/products.js`, adjust line 81 so the middleware order becomes `productsDeleteLimiter, checkAuth, ProductsController.products_delete_product` instead of `checkAuth, productsDeleteLimiter, ...`. No new imports, methods, or definitions are required; we only change the middleware order for that route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
