### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/node-rest-api/api/routes/products.js
+++ b/node-rest-api/api/routes/products.js
@@ -72,7 +72,7 @@ const productsCreateLimiter = RateLimit({
  */
 router.get('/', productsGetAllLimiter, ProductsController.products_get_all);
 
-router.post('/', checkAuth, productsCreateLimiter, upload.single('productImage'), ProductsController.products_create_product);
+router.post('/', productsCreateLimiter, checkAuth, upload.single('productImage'), ProductsController.products_create_product);
 
 router.get('/:productId', productsGetByIdLimiter, ProductsController.products_get_product);
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeemherrera/DataClient/security/code-scanning/27](https://github.com/jorgeemherrera/DataClient/security/code-scanning/27)

In general, to fix this class of issue you must ensure that a rate-limiting middleware executes before any expensive work (authorization, file handling, DB operations) in the request lifecycle. For Express, this means placing the limiter earlier in the middleware list for each vulnerable route, or applying a limiter globally to routes that do such work.

For this specific file, the best fix without changing existing behavior is to reorder middleware for the POST `/` route so that `productsCreateLimiter` runs before `checkAuth`. This way, excessive requests are rejected by the limiter before the server does authorization checks or processes file uploads. No new imports or additional logic are required, because the file already defines `productsCreateLimiter` using `express-rate-limit`. Only line 75 in `node-rest-api/api/routes/products.js` needs to be updated so the parameter order becomes: path, limiter, `checkAuth`, `upload.single(...)`, controller.

Concretely:
- In `node-rest-api/api/routes/products.js`, move `productsCreateLimiter` to be the first middleware after the route path on the POST `/` route.
- Keep the rest of the middlewares and controllers unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
